### PR TITLE
Add interfaces, UML theme and improved argument parsing.

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,0 +1,3 @@
+{
+  "flutter": "stable"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ migrate_working_dir/
 .dart_tool/
 .packages
 build/
-.fvm
 
 # Compiled class file
 *.class
@@ -54,3 +53,6 @@ build/
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# FVM Version Cache
+.fvm/

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,28 +1,7 @@
-include: package:flutter_lints/flutter.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   exclude: [ build/** , /**/*.freezed.dart, /**/*.g.dart ]
   language:
     strict-casts: true
     strict-raw-types: true
-
-linter:
-  rules:
-    await_only_futures: true
-    use_string_buffers: true
-    use_build_context_synchronously: true
-    avoid_annotating_with_dynamic: true
-    avoid_as: true
-    always_declare_return_types: true
-    prefer_void_to_null: true
-    prefer_is_not_empty: true
-    prefer_is_empty: true
-    prefer_final_parameters: true
-    prefer_final_locals: true
-    prefer_final_in_for_each: true
-    prefer_final_fields: true
-    prefer_const_declarations: true
-    prefer_const_constructors_in_immutables: true
-    prefer_const_constructors: true
-    prefer_relative_imports: true
-    prefer_single_quotes: true

--- a/bin/code_uml.dart
+++ b/bin/code_uml.dart
@@ -38,7 +38,7 @@ void main(final List<String> arguments) async {
         help: 'Output directory to save the generate UML file',
         valueHelp: 'output_dir',
         defaultsTo: './uml')
-    ..addMultiOption('exclde-files',
+    ..addMultiOption('exclude-files',
         abbr: 'e',
         help: 'Files to exclude from analysis, this will try to match the'
             ' end of the file(s) found in the input directories, '
@@ -71,5 +71,5 @@ void main(final List<String> arguments) async {
   final analyzer = CodeUml(reporter: reporter, logger: logger);
 
   analyzer.analyze(input.toList(growable: false),
-      excludeFiles: argsResults['exclde-files'] as List<String>);
+      excludeFiles: argsResults['exclude-files'] as List<String>);
 }

--- a/bin/code_uml.dart
+++ b/bin/code_uml.dart
@@ -38,6 +38,13 @@ void main(final List<String> arguments) async {
         help: 'Output directory to save the generate UML file',
         valueHelp: 'output_dir',
         defaultsTo: './uml')
+    ..addMultiOption('exclde-files',
+        abbr: 'e',
+        help: 'Files to exclude from analysis, this will try to match the'
+            ' end of the file(s) found in the input directories, '
+            'specify multiple with additional -e options',
+        valueHelp: 'exclude_files',
+        defaultsTo: [])
     ..addFlag('verbose', abbr: 'v', help: 'Verbose output', negatable: false);
   final ArgResults argsResults;
   try {
@@ -63,5 +70,6 @@ void main(final List<String> arguments) async {
   final reporter = Reporter.file(reportTo, converter);
   final analyzer = CodeUml(reporter: reporter, logger: logger);
 
-  analyzer.analyze(input.toList(growable: false));
+  analyzer.analyze(input.toList(growable: false),
+      excludeFiles: argsResults['exclde-files'] as List<String>);
 }

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -23,7 +23,7 @@ class CodeUml {
   List<String> _getFilePathsFromDir(final List<String> dirsPath) {
     final files = <String>[];
     for (final dirPath in dirsPath) {
-      final dir = Directory(dirPath);
+      final dir = Directory(dirPath).absolute;
 
       dir.listSync(recursive: true).forEach((final fileEntity) {
         if (fileEntity.statSync().type != FileSystemEntityType.file ||
@@ -31,7 +31,8 @@ class CodeUml {
           return;
         }
 
-        final path = fileEntity.path;
+        final path = fileEntity.absolute.resolveSymbolicLinksSync();
+
         files.add(path);
       });
     }
@@ -69,9 +70,9 @@ class CodeUml {
 
   /// Analyzes a class for methods, fields, inheritance, implementations, and dependencies
   ClassDef _analyzeClass(final ClassDeclaration classDeclaration) {
-    final extendsOf = classDeclaration.extendsClause?.superclass.name2.lexeme;
+    final extendsOf = classDeclaration.extendsClause?.superclass.name.lexeme;
     final implementsOf = classDeclaration.implementsClause?.interfaces
-            .map((final e) => e.name2.lexeme)
+            .map((final e) => e.name.lexeme)
             .toList() ??
         [];
     final classDef = ClassDef();
@@ -79,6 +80,9 @@ class CodeUml {
     classDef.extendsOf = extendsOf;
     classDef.isAbstract = classDeclaration.abstractKeyword != null;
     classDef.implementsOf.addAll(implementsOf);
+    classDef.isInterface = classDeclaration.interfaceKeyword != null;
+    classDef.isMixin = classDeclaration.mixinKeyword != null;
+
     for (final member in classDeclaration.members) {
       if (member is MethodDeclaration) {
         classDef.methods.add(_analyzeMethod(member));

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -39,11 +39,26 @@ class CodeUml {
     return files;
   }
 
-  Future<void> analyze(final List<String> dirsPath) async {
+  Future<void> analyze(final List<String> dirsPath,
+      {final List<String> excludeFiles = const []}) async {
     if (dirsPath.isEmpty) {
       throw Exception('Directories are not specified');
     }
     final includedPaths = _getFilePathsFromDir(dirsPath).toList();
+    // Exclude specified files
+    if (excludeFiles.isNotEmpty) {
+      final matchedExculdes = includedPaths.where((final path) {
+        return excludeFiles.any((final exclude) => path.endsWith(exclude));
+      }).toList();
+      if (matchedExculdes.isNotEmpty) {
+        logger.info('Excluding files:', onlyVerbose: false);
+        for (final exclude in matchedExculdes) {
+          logger.info('\t$exclude', onlyVerbose: false);
+          includedPaths.remove(exclude);
+        }
+      }
+    }
+
     final classesDef = <ClassDef>[];
     final collection = AnalysisContextCollection(includedPaths: includedPaths);
 

--- a/lib/src/class_def.dart
+++ b/lib/src/class_def.dart
@@ -23,4 +23,6 @@ class ClassDef {
   String name = '';
   String? extendsOf;
   bool isAbstract = false;
+  bool isInterface = false;
+  bool isMixin = false;
 }

--- a/lib/src/converters/converter.dart
+++ b/lib/src/converters/converter.dart
@@ -5,15 +5,17 @@ part 'plant_uml_converter.dart';
 
 /// This class converts definitions to uml code
 sealed class Converter {
-  factory Converter(final String converterType) {
+  factory Converter(final String converterType, {final String? theme}) {
     switch (converterType) {
       case 'mermaid':
-        return MermaidUmlConverter();
+        return MermaidUmlConverter(theme: theme);
       case 'plantuml':
       default:
-        return PlantUmlConverter();
+        return PlantUmlConverter(theme: theme);
     }
   }
+
+  String? get theme;
 
   /// Public access modifier
   String get publicAccessModifier;

--- a/lib/src/converters/mermaid_uml_converter.dart
+++ b/lib/src/converters/mermaid_uml_converter.dart
@@ -1,11 +1,18 @@
 part of 'converter.dart';
 
 final class MermaidUmlConverter implements Converter {
-  MermaidUmlConverter();
+  @override
+  final String? theme;
+
+  MermaidUmlConverter({this.theme});
 
   @override
   String convertToText(final List<ClassDef> defs) {
     final stringBuffer = StringBuffer();
+    if (theme != null) {
+      // Add YAML front matter for Mermaid theme
+      stringBuffer.write('---\nconfig:\n  theme: $theme\n---\n');
+    }
     stringBuffer.write('classDiagram\n');
 
     for (final def in defs) {

--- a/lib/src/converters/plant_uml_converter.dart
+++ b/lib/src/converters/plant_uml_converter.dart
@@ -1,14 +1,20 @@
 part of 'converter.dart';
 
 final class PlantUmlConverter implements Converter {
-  PlantUmlConverter();
+  @override
+  final String? theme;
+
+  PlantUmlConverter({this.theme});
 
   @override
   String convertToText(final List<ClassDef> defs) {
     final stringBuffer = StringBuffer('@startuml\n');
+    if (theme != null) {
+      stringBuffer.write('!theme $theme\n');
+    }
 
     for (final def in defs) {
-      stringBuffer.write(def.isAbstract ? 'abstract ' : '');
+      stringBuffer.write(def.isAbstract && !def.isInterface ? 'abstract ' : '');
       stringBuffer.write(convertStartClass(def));
       stringBuffer.write(convertFields(def));
       stringBuffer.write(methodsDivider);
@@ -60,7 +66,8 @@ final class PlantUmlConverter implements Converter {
   }
 
   @override
-  String convertStartClass(final ClassDef def) => 'class ${def.name} {\n';
+  String convertStartClass(final ClassDef def) =>
+      '${def.isInterface ? "interface" : "class"} ${def.name} {\n';
 
   @override
   String convertEndClass(final ClassDef def) => '}\n';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: code_uml
 description: This package help you build UML diagram. You have to copy result from result file and paste in PlantUML
-version: 1.0.2
+version: 1.1.0
 homepage: https://github.com/chashkovdaniil/graph_analyzer/
 repository: https://github.com/chashkovdaniil/graph_analyzer/
 
@@ -11,13 +11,13 @@ executables:
   code_uml:
 
 dependencies:
-  analyzer: ^6.4.1
+  analyzer: ^8.1.1
   args: ^2.4.2
   io: ^1.0.4
   path: ^1.9.0
 
 dev_dependencies:
-  lints: ^2.0.0   
+  lints: ^6.0.0   
 
 topics:
   - analysis


### PR DESCRIPTION
This changes a few argument names and help text:

```text
Usage:

-h, --help                            Show this help
-u, --uml=<uml_variant>               UML variant

          [plantuml] (default)        PlantUML
          [mermaid]                   Mermaid uml

-t, --theme=<theme_name>              Theme for the UML diagram (must match the selected UML variant)
-i, --input=<analysis_dirs>           Input directories for analysis, specify multiple with additional -i options
                                      (defaults to "./lib")
-o, --output=<output_dir>             Output directory to save the generate UML file
                                      (defaults to "./uml")
-e, --exclude-files=<exclude_files>    Files to exclude from analysis, this will try to match the end of the file(s) found in the input directories, specify multiple with additional -e options
-v, --verbose                         Verbose output
```

It adds the option to specify a (unvalidated) theme for the UML output, and adds interface support for PlantUML.

There is also an exclude option to skip paths where the end of the path matches an "-e" option.